### PR TITLE
Use Ansible's reboot module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ language: python
 python:
   - "3.6"
 env:
-  - ANSIBLE="2.5"
-  - ANSIBLE="2.6"
   - ANSIBLE="2.7"
   - ANSIBLE="2.8"
   - ANSIBLE="2.9"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: BSD
 
-  min_ansible_version: 2.5
+  min_ansible_version: 2.7
 
   platforms:
     - name: Debian

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,21 +16,8 @@
   with_items: '{{ boot_config_lines }}'
   register: _boot_config_lines
 
-- name: restart machine  # noqa 503
-  shell: sleep 2 && shutdown -r now "/boot/config.txt config changed"
-  async: 1
-  poll: 0
-  ignore_errors: true
-  when: _boot_config.changed or _boot_config_lines.changed
-
-
-- name: waiting for machine to come back  # noqa 503
-  delegate_to: localhost
-  connection: local
-  wait_for:
-    port: 22
-    host: "{{ ansible_ssh_host|default(ansible_host)|default(inventory_hostname) }}"
-    delay: 20
-    timeout: 120
-  become: false
+- name: "restart machine"  # noqa 503
+  reboot:
+    msg: "Reboot by Ansible, because /boot/config.txt config changed."
+    reboot_timeout: 300   # (= 5 minutes)
   when: _boot_config.changed or _boot_config_lines.changed

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,13 @@
 [tox]
 minversion = 1.8
-envlist = py{36}-ansible{25,26,27,28,29}
+envlist = py{36}-ansible{27,28,29}
 skipsdist = true
 
 [testenv]
-# ansible only supports python3 in versions >= 2.5
 basepython = python3
 passenv = *
 deps =
     -rrequirements.txt
-    ansible25: ansible>=2.5,<2.6
-    ansible26: ansible>=2.6,<2.7
     ansible27: ansible>=2.7,<2.8
     # https://github.com/ansible/molecule/issues/1727
     ansible28: testinfra>=3.0.4
@@ -25,12 +22,10 @@ commands =
 
 [travis]
 os =
-  linux: py{36}-ansible{25,26,27,28,29}
+  linux: py{36}-ansible{27,28,29}
 
 [travis:env]
 ANSIBLE =
-  2.5: ansible25
-  2.6: ansible26
   2.7: ansible27
   2.8: ansible28
   2.9: ansible29


### PR DESCRIPTION
As of Ansible 2.7 the reboot module is available to reboot machines and
wait for them to come back up. This commit replaces the call to the
shell and shutdown command by this module. Simplifies the code.
Updated meta information to match, minimal Ansible is now 2.7.